### PR TITLE
bump thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ solana-accounts-db = "=2.0.13"
 solana-runtime = "=2.0.13"
 solana-sdk = "=2.0.13"
 tar = "0.4.38"
-thiserror = "1.0.31"
+thiserror = "1.0.57"
 tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros"] }
 zstd = "0.11.2"
 


### PR DESCRIPTION
Error in ingestooor ci 

```
19.86 all possible versions conflict with previously selected packages.
19.86 
19.86   previously selected package `thiserror v1.0.57`
19.86     ... which satisfies dependency `thiserror = "^1.0.31"` (locked to 1.0.57) of package `solana-snapshot-etl v0.6.0 (https://github.com/step-finance/solana-snapshot-etl.git?rev=c591cb50eb080a8aa31c4f137fdfa85931e7e64c#c591cb50)`
19.86     ... which satisfies git dependency `solana-snapshot-etl` (locked to 0.6.0) of package `state_initializer v0.0.1 (/app/crates/state_initializer)`
19.86 
19.86 failed to select a version for `thiserror` which could resolve this conflict
19.87 thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-chef-0.1.67/src/recipe.rs:218:27:
19.87 Exited with status code: 101
19.87 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------
Dockerfile:17
--------------------
  15 |     COPY --from=planner /app/recipe.json recipe.json
  16 |     # Build dependencies - this is the caching Docker layer!
  17 | >>> RUN --mount=type=ssh cargo chef cook --release --recipe-path recipe.json
  18 |     COPY ./.cargo/config.toml ./.cargo/config.toml
  19 |     COPY ./Cargo.lock ./Cargo.lock
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo chef cook --release --recipe-path recipe.json" did not complete successfully: exit code: 101

```